### PR TITLE
Feat: Previous devfest year speakers will show only in previous speakers section

### DIFF
--- a/public/data/resources.json
+++ b/public/data/resources.json
@@ -201,7 +201,7 @@
       "label": "View all",
       "link": "/previous-speakers"
     },
-    "previousSpeakerYear": 2019
+    "previousDevFestYear": 2019
   },
   "galleryBlock": {
     "title": "#devfestahm19 highlights",

--- a/public/data/resources.json
+++ b/public/data/resources.json
@@ -200,7 +200,8 @@
     "callToAction": {
       "label": "View all",
       "link": "/previous-speakers"
-    }
+    },
+    "previousSpeakerYear": 2019
   },
   "galleryBlock": {
     "title": "#devfestahm19 highlights",

--- a/src/elements/previous-speakers-block.ts
+++ b/src/elements/previous-speakers-block.ts
@@ -124,7 +124,7 @@ export class PreviousSpeakersBlock extends ReduxMixin(PolymerElement) {
 
   override stateChanged(state: RootState) {
     this.previousSpeakers = state.previousSpeakers;
-    this.speakers = selectRandomPreviousSpeakers(state);
+    this.speakers = selectRandomPreviousSpeakers(state, previousSpeakersBlock.previousSpeakerYear);
   }
 
   override connectedCallback() {

--- a/src/elements/previous-speakers-block.ts
+++ b/src/elements/previous-speakers-block.ts
@@ -124,7 +124,7 @@ export class PreviousSpeakersBlock extends ReduxMixin(PolymerElement) {
 
   override stateChanged(state: RootState) {
     this.previousSpeakers = state.previousSpeakers;
-    this.speakers = selectRandomPreviousSpeakers(state, previousSpeakersBlock.previousSpeakerYear);
+    this.speakers = selectRandomPreviousSpeakers(state, previousSpeakersBlock.previousDevFestYear);
   }
 
   override connectedCallback() {

--- a/src/store/previous-speakers/selectors.ts
+++ b/src/store/previous-speakers/selectors.ts
@@ -3,9 +3,13 @@ import { createSelector } from '@reduxjs/toolkit';
 import { RootState, store } from '..';
 import { PreviousSpeaker } from '../../models/previous-speaker';
 import { randomOrder } from '../../utils/arrays';
-import { selectViewport } from '../ui/selectors';
-import { Viewport } from '../ui/types';
+import { ViewportAndYear } from '../ui/types';
 import { fetchPreviousSpeakers } from './actions';
+
+export const selectViewPortAndYear = (state: RootState, year: number): ViewportAndYear => ({
+  viewport: state.ui.viewport,
+  year,
+});
 
 const selectSpeakerId = (_state: RootState, speakerId: string) => speakerId;
 
@@ -29,9 +33,11 @@ export const selectPreviousSpeaker = createSelector(
 
 export const selectRandomPreviousSpeakers = createSelector(
   selectPreviousSpeakers,
-  selectViewport,
-  (previousSpeakers: PreviousSpeaker[], viewport: Viewport): PreviousSpeaker[] => {
+  selectViewPortAndYear,
+  (previousSpeakers: PreviousSpeaker[], { viewport, year }: ViewportAndYear): PreviousSpeaker[] => {
     const displayCount = viewport.isPhone ? 8 : 14;
-    return randomOrder(previousSpeakers).slice(0, displayCount);
+    return randomOrder(previousSpeakers)
+      .filter((speaker) => speaker.sessions[year])
+      .slice(0, displayCount);
   }
 );

--- a/src/store/ui/types.ts
+++ b/src/store/ui/types.ts
@@ -17,6 +17,11 @@ export type Viewport = {
   [index in VIEWPORT]: boolean;
 };
 
+export interface ViewportAndYear {
+  viewport: Viewport;
+  year: number;
+}
+
 export interface SetViewport {
   size: VIEWPORT;
   matches: boolean;


### PR DESCRIPTION
- Added 2019 speakers list only in the previous speakers section of the footer section
- Created dynamic variable of the year in the `resource.json` so you can change it in the future to show different year speakers.