### PR TITLE
[Fix] added missing mailto

### DIFF
--- a/public/data/posts/2023-09-05-c4p.md
+++ b/public/data/posts/2023-09-05-c4p.md
@@ -115,6 +115,6 @@ Well, do you know a better way to attend the conference? Here are our top 3 reas
 
 **Please note:** There is no guarantee that a submission will be put onto the conference agenda! The program committee picks the most interesting talk proposals and informs the selected submitters max by 25th September, 2023.
 
-Any questions? Email any organisers at [pareshmayani@gmail.com](mailto:pareshmayani@gmail.com)  OR [dhuma1981@gmail.com](dhuma1981@gmail.com) OR [hdave10@gmail.com](hdave10@gmail.com).
+Any questions? Email any organisers at [pareshmayani@gmail.com](mailto:pareshmayani@gmail.com)  OR [dhuma1981@gmail.com](mailto:dhuma1981@gmail.com) OR [hdave10@gmail.com](mailto:hdave10@gmail.com).
 
 <div layout horizontal center-justified> <a href="https://sessionize.com/gdg-ahmedabad-devfest-2023/" rel="noopener noreferrer"> <paper-button primary>Submit a proposal</paper-button> </a> </div>


### PR DESCRIPTION
Added missing `mailto:`s.

---

Without `mailto:`, it attempts to open the following URLs which results in 404.

<img src='https://github.com/GDGAhmedabad/devfestahm/assets/13456345/b2a28a84-dd7d-4b17-baac-b6a61feee37c' width=300>

```
https://devfest.gdgahmedabad.com/dhuma1981@gmail.com

https://devfest.gdgahmedabad.com/hdave10@gmail.com
```