### PR TITLE
Fix LinkedIn URL in Team Section

### DIFF
--- a/public/data/firestore-data.json
+++ b/public/data/firestore-data.json
@@ -2498,7 +2498,7 @@
           "socials": [
             {
               "icon": "linkedin",
-              "link": "www.linkedin.com/in/mira-patel-76086a267",
+              "link": "https://www.linkedin.com/in/mira-patel-76086a267",
               "name": "LinkedIn"
             }
           ],


### PR DESCRIPTION
Without http or https it attempts open in on devfestahm's site itself - https://devfest.gdgahmedabad.com/www.linkedin.com/in/mira-patel-76086a267

<img width=350 src='https://github.com/user-attachments/assets/2207e76b-0b32-466b-b68c-baa44d0d0783'>
